### PR TITLE
Override Django XML Test Runner

### DIFF
--- a/backend/gsr_booking/models.py
+++ b/backend/gsr_booking/models.py
@@ -45,7 +45,6 @@ class GroupMembership(models.Model):
         super().save(*args, **kwargs)
 
     def check_wharton(self):
-        print("i went here")
         # not using api_wrapper.py to prevent circular dependency
         url = f"https://apps.wharton.upenn.edu/gsr/api/v1/{self.user.username}/privileges"
         try:

--- a/backend/gsr_booking/models.py
+++ b/backend/gsr_booking/models.py
@@ -45,6 +45,7 @@ class GroupMembership(models.Model):
         super().save(*args, **kwargs)
 
     def check_wharton(self):
+        print("i went here")
         # not using api_wrapper.py to prevent circular dependency
         url = f"https://apps.wharton.upenn.edu/gsr/api/v1/{self.user.username}/privileges"
         try:

--- a/backend/pennmobile/settings/base.py
+++ b/backend/pennmobile/settings/base.py
@@ -156,6 +156,9 @@ REST_FRAMEWORK = {
     ],
 }
 
+# Override default Django Test Runner to include test suite-wide Mock Patch
+TEST_RUNNER = "pennmobile.test_runner.MobileTestRunner"
+
 # Laundry API URL
 LAUNDRY_URL = os.environ.get("LAUNDRY_URL", "http://suds.kite.upenn.edu")
 

--- a/backend/pennmobile/settings/ci.py
+++ b/backend/pennmobile/settings/ci.py
@@ -1,6 +1,6 @@
 from pennmobile.settings.base import *  # noqa: F401, F403
 
 
-TEST_RUNNER = "xmlrunner.extra.djangotestrunner.XMLTestRunner"
+# Settings used for XMLTestRunner
 TEST_OUTPUT_VERBOSE = 2
 TEST_OUTPUT_DIR = "test-results"

--- a/backend/pennmobile/test_runner.py
+++ b/backend/pennmobile/test_runner.py
@@ -10,4 +10,5 @@ def check_wharton(*args):
 class MobileTestRunner(DiscoverRunner):
     @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def run_tests(self, test_labels, **kwargs):
+        print('i also went here')
         return super().run_tests(test_labels, **kwargs)

--- a/backend/pennmobile/test_runner.py
+++ b/backend/pennmobile/test_runner.py
@@ -10,5 +10,5 @@ def check_wharton(*args):
 class MobileTestRunner(DiscoverRunner):
     @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def run_tests(self, test_labels, **kwargs):
-        print('i also went here')
+        print("i also went here")
         return super().run_tests(test_labels, **kwargs)

--- a/backend/pennmobile/test_runner.py
+++ b/backend/pennmobile/test_runner.py
@@ -10,5 +10,4 @@ def check_wharton(*args):
 class MobileTestRunner(XMLTestRunner):
     @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def run_tests(self, test_labels, **kwargs):
-        print("i also went here")
         return super().run_tests(test_labels, **kwargs)

--- a/backend/pennmobile/test_runner.py
+++ b/backend/pennmobile/test_runner.py
@@ -1,0 +1,13 @@
+from unittest import mock
+
+from django.test.runner import DiscoverRunner
+
+
+def check_wharton(*args):
+    return False
+
+
+class MobileTestRunner(DiscoverRunner):
+    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
+    def run_tests(self, test_labels, **kwargs):
+        return super().run_tests(test_labels, **kwargs)

--- a/backend/pennmobile/test_runner.py
+++ b/backend/pennmobile/test_runner.py
@@ -1,13 +1,13 @@
 from unittest import mock
 
-from django.test.runner import DiscoverRunner
+from xmlrunner.extra.djangotestrunner import XMLTestRunner
 
 
 def check_wharton(*args):
     return False
 
 
-class MobileTestRunner(DiscoverRunner):
+class MobileTestRunner(XMLTestRunner):
     @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def run_tests(self, test_labels, **kwargs):
         print("i also went here")

--- a/backend/tests/dining/test_views.py
+++ b/backend/tests/dining/test_views.py
@@ -12,10 +12,6 @@ from rest_framework.test import APIClient
 from dining.models import DiningBalance, DiningTransaction, Venue
 
 
-def check_wharton(*args):
-    return False
-
-
 User = get_user_model()
 
 
@@ -99,7 +95,6 @@ class TestItem(TestCase):
 
 
 class TestPreferences(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_venues")
         self.client = APIClient()
@@ -145,7 +140,6 @@ class TestPreferences(TestCase):
 
 
 class TestTransactions(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_venues")
         self.client = APIClient()
@@ -188,7 +182,6 @@ class TestTransactions(TestCase):
 
 
 class TestBalance(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_venues")
         self.client = APIClient()
@@ -232,7 +225,6 @@ class TestBalance(TestCase):
 
 
 class TestAverageBalance(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_venues")
         self.client = APIClient()
@@ -277,7 +269,6 @@ class TestAverageBalance(TestCase):
 
 
 class TestProjection(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_venues")
         self.client = APIClient()

--- a/backend/tests/gsr_booking/test_gsr_booking.py
+++ b/backend/tests/gsr_booking/test_gsr_booking.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from rest_framework.test import APIClient
@@ -7,15 +5,10 @@ from rest_framework.test import APIClient
 from gsr_booking.models import Group, GroupMembership
 
 
-def check_wharton(*args):
-    return False
-
-
 User = get_user_model()
 
 
 class UserViewTestCase(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.user1 = User.objects.create_user(
             username="user1", password="password", first_name="user", last_name="one"
@@ -49,7 +42,6 @@ class UserViewTestCase(TestCase):
 
 
 class MembershipViewTestCase(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.user1 = User.objects.create_user(username="user1", password="password")
         self.user2 = User.objects.create_user(username="user2", password="password")
@@ -65,7 +57,6 @@ class MembershipViewTestCase(TestCase):
         )
         self.assertEqual(200, response.status_code)
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def test_bulk_invite(self):
         User.objects.create_user(username="user3", password="password")
         self.client.login(username="user2", password="password")
@@ -114,7 +105,6 @@ class MembershipViewTestCase(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertTrue(GroupMembership.objects.get(pk=mem.pk).accepted)
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def test_wrong_user_accept_invite_fails(self):
         user3 = User.objects.create_user(username="user3", password="password")
         mem = GroupMembership.objects.create(user=user3, group=self.group2, accepted=False)
@@ -133,7 +123,6 @@ class MembershipViewTestCase(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertFalse(GroupMembership.objects.filter(pk=mem.pk).exists())
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def test_wrong_user_decline_invite_fails(self):
         user3 = User.objects.create_user(username="user3", password="password")
         mem = GroupMembership.objects.create(user=user3, group=self.group2, accepted=False)
@@ -159,7 +148,6 @@ class MembershipViewTestCase(TestCase):
 
 
 class GroupTestCase(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.user1 = User.objects.create_user(username="user1", password="password")
         self.user2 = User.objects.create_user(username="user2", password="password")

--- a/backend/tests/gsr_booking/test_gsr_views.py
+++ b/backend/tests/gsr_booking/test_gsr_views.py
@@ -13,10 +13,6 @@ from gsr_booking.models import GSR, Group, GSRBooking
 User = get_user_model()
 
 
-def check_wharton(*args, **kwargs):
-    return False
-
-
 def is_wharton_false(*args):
     return False
 
@@ -45,7 +41,6 @@ def reservations(*args):
 
 
 class TestGSRs(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_gsrs")
         self.user = User.objects.create_user("user", "user@seas.upenn.edu", "user")
@@ -68,7 +63,6 @@ class TestGSRs(TestCase):
 
 
 class TestGSRFunctions(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_gsrs")
         self.user = User.objects.create_user("user", "user@sas.upenn.edu", "user")
@@ -112,7 +106,6 @@ class TestGSRFunctions(TestCase):
         self.assertEqual(1, len(res_json))
         self.assertTrue(res_json["is_wharton"])
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     @mock.patch("gsr_booking.views.BW.get_availability", libcal_availability)
     def test_availability_libcal(self):
         response = self.client.get(reverse("availability", args=["1086", "1889"]))
@@ -127,7 +120,6 @@ class TestGSRFunctions(TestCase):
             self.assertIn("id", room)
             self.assertIn("availability", room)
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     @mock.patch("gsr_booking.views.BW.get_availability", wharton_availability)
     def test_availability_wharton(self):
         response = self.client.get(reverse("availability", args=["JMHH", "1"]))

--- a/backend/tests/gsr_booking/test_gsr_wrapper.py
+++ b/backend/tests/gsr_booking/test_gsr_wrapper.py
@@ -13,10 +13,6 @@ from gsr_booking.models import GSR, Group, GSRBooking, Reservation
 User = get_user_model()
 
 
-def check_wharton(*args):
-    return False
-
-
 def mock_requests_get(obj, *args, **kwargs):
     class Mock:
         def __init__(self, json_data, status_code):
@@ -54,7 +50,6 @@ def mock_requests_get(obj, *args, **kwargs):
 
 
 class TestBookingWrapper(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_gsrs")
         self.user = User.objects.create_user("user", "user@seas.upenn.edu", "user")

--- a/backend/tests/laundry/test_views.py
+++ b/backend/tests/laundry/test_views.py
@@ -11,10 +11,6 @@ from laundry.models import LaundryRoom, LaundrySnapshot
 from tests.laundry.test_commands import fakeLaundryGet
 
 
-def check_wharton(*args):
-    return False
-
-
 User = get_user_model()
 
 
@@ -154,7 +150,6 @@ class HallUsageViewTestCase(TestCase):
 
 @mock.patch("requests.get", fakeLaundryGet)
 class PreferencesTestCase(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         LaundryRoom.objects.get_or_create(
             hall_id=0, name="Bishop White", location="Quad", total_washers=9, total_dryers=9

--- a/backend/tests/penndata/test_views.py
+++ b/backend/tests/penndata/test_views.py
@@ -15,10 +15,6 @@ from penndata.models import Event, FitnessRoom, FitnessSnapshot
 from portal.models import Poll, Post
 
 
-def check_wharton(*args):
-    return False
-
-
 def fakeFitnessGet(url, *args, **kwargs):
     if "docs.google.com/spreadsheets/" in url:
         with open("tests/penndata/fitness_snapshot.html", "rb") as f:
@@ -90,7 +86,6 @@ class TestEvent(TestCase):
 
 
 class TestHomePage(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_venues")
         call_command("load_laundry_rooms")
@@ -135,7 +130,6 @@ class TestHomePage(TestCase):
 
 
 class TestGetRecentFitness(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_fitness_rooms")
         self.client = APIClient()
@@ -191,7 +185,6 @@ class TestGetFitnessSnapshot(TestCase):
 
 
 class TestAnalytics(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.client = APIClient()
         self.test_user = User.objects.create_user("user", "user@a.com", "user")

--- a/backend/tests/portal/test_permissions.py
+++ b/backend/tests/portal/test_permissions.py
@@ -12,10 +12,6 @@ from rest_framework.test import APIClient
 from portal.models import Poll, PollOption, PollVote
 
 
-def check_wharton(*args):
-    return False
-
-
 User = get_user_model()
 
 
@@ -25,7 +21,6 @@ def mock_get_user_clubs(*args, **kwargs):
 
 
 class PollPermissions(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_target_populations")
 

--- a/backend/tests/portal/test_polls.py
+++ b/backend/tests/portal/test_polls.py
@@ -14,10 +14,6 @@ from portal.models import Poll, PollOption, PollVote, TargetPopulation
 User = get_user_model()
 
 
-def check_wharton(*args):
-    return False
-
-
 def mock_get_user_clubs(*args, **kwargs):
     with open("tests/portal/get_user_clubs.json") as data:
         return json.load(data)
@@ -36,7 +32,6 @@ def mock_get_club_info(*args, **kwargs):
 class TestUserClubs(TestCase):
     """Test User and Club information"""
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.client = APIClient()
         self.test_user = User.objects.create_user("user", "user@seas.upenn.edu", "user")
@@ -59,7 +54,6 @@ class TestUserClubs(TestCase):
 class TestPolls(TestCase):
     """Tests Create/Update/Retrieve for Polls and Poll Options"""
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     @mock.patch("portal.serializers.get_user_clubs", mock_get_user_clubs)
     def setUp(self):
         call_command("load_target_populations")
@@ -176,7 +170,6 @@ class TestPolls(TestCase):
         self.client.patch(f'/portal/options/{res_json["id"]}/', payload_2)
         self.assertEqual("no!", PollOption.objects.get(id=res_json["id"]).choice)
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def test_review_poll(self):
         Poll.objects.create(
             club_code="pennlabs",
@@ -228,7 +221,6 @@ class TestPolls(TestCase):
 class TestPollVotes(TestCase):
     """Tests Create/Update Polls and History"""
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_target_populations")
         self.target_id = TargetPopulation.objects.get(population="2024").id

--- a/backend/tests/portal/test_posts.py
+++ b/backend/tests/portal/test_posts.py
@@ -14,10 +14,6 @@ from portal.models import Post, TargetPopulation
 User = get_user_model()
 
 
-def check_wharton(*args):
-    return False
-
-
 def mock_get_user_clubs(*args, **kwargs):
     with open("tests/portal/get_user_clubs.json") as data:
         return json.load(data)
@@ -40,7 +36,6 @@ def mock_get_club_info(*args, **kwargs):
 class TestPosts(TestCase):
     """Tests Created/Update/Retrieve for Posts"""
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     @mock.patch("portal.serializers.get_user_clubs", mock_get_user_clubs)
     def setUp(self):
         call_command("load_target_populations")
@@ -112,7 +107,6 @@ class TestPosts(TestCase):
         # since the user is not an admin, approved should be set to false after update
         self.assertEqual(Post.STATUS_DRAFT, res_json["status"])
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     @mock.patch("portal.views.get_user_clubs", mock_get_user_clubs)
     @mock.patch("portal.permissions.get_user_clubs", mock_get_user_clubs)
     def test_update_post_admin(self):
@@ -142,7 +136,6 @@ class TestPosts(TestCase):
         self.assertEqual(1, len(res_json))
         self.assertEqual(2, Post.objects.all().count())
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def test_review_post_no_admin_comment(self):
         # No admin comment
         Post.objects.create(

--- a/backend/tests/user/test_notifs.py
+++ b/backend/tests/user/test_notifs.py
@@ -16,10 +16,6 @@ from user.models import NotificationSetting, NotificationToken
 User = get_user_model()
 
 
-def check_wharton(*args):
-    return False
-
-
 def mock_send_notif(*args, **kwargs):
     # used for mocking notification sends
     return
@@ -33,7 +29,6 @@ def mock_get_path(*args, **kwargs):
 class TestNotificationToken(TestCase):
     """Tests for CRUD Notification Tokens"""
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.client = APIClient()
         self.test_user = User.objects.create_user("user", "user@seas.upenn.edu", "user")
@@ -80,7 +75,6 @@ class TestNotificationToken(TestCase):
 class TestNotificationSetting(TestCase):
     """Tests for CRUD Notification Settings"""
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.client = APIClient()
         self.test_user = User.objects.create_user("user", "user@seas.upenn.edu", "user")
@@ -136,7 +130,6 @@ class TestNotificationSetting(TestCase):
 class TestNotificationAlert(TestCase):
     """Tests for sending Notification Alerts"""
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.client = APIClient()
 
@@ -205,7 +198,6 @@ class TestNotificationAlert(TestCase):
 class TestSendGSRReminders(TestCase):
     """Test Sending GSR Reminders"""
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         call_command("load_gsrs")
         self.client = APIClient()
@@ -257,7 +249,6 @@ class TestSendGSRReminders(TestCase):
 class TestSendShadowNotifs(TestCase):
     """Test Sending Shadow Notifications"""
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.client = APIClient()
         self.test_user = User.objects.create_user("user", "user@seas.upenn.edu", "user")
@@ -282,7 +273,6 @@ class TestSendShadowNotifs(TestCase):
 class TestCallingNotificationsAPI(TestCase):
     """Test Calling API Notifications"""
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.client = APIClient()
         self.test_user = User.objects.create_user("user", "user@seas.upenn.edu", "user")

--- a/backend/tests/user/test_user.py
+++ b/backend/tests/user/test_user.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from django.contrib import auth
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -8,15 +6,10 @@ from rest_framework.test import APIClient
 from user.models import Profile
 
 
-def check_wharton(*args):
-    return False
-
-
 User = get_user_model()
 
 
 class UserTestCase(TestCase):
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def setUp(self):
         self.user1 = {
             "pennid": 1,
@@ -45,14 +38,12 @@ class UserTestCase(TestCase):
         self.client = APIClient()
         self.client.login(username="user1", password="password")
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def test_user1_profile(self):
         user = auth.authenticate(remote_user=self.user1)
         self.assertEqual(1, Profile.objects.all().count())
         self.assertEqual(user, Profile.objects.all().first().user)
         self.assertEqual("user", str(Profile.objects.all().first()))
 
-    @mock.patch("gsr_booking.models.GroupMembership.check_wharton", check_wharton)
     def test_user2_profile(self):
         self.assertEqual(0, Profile.objects.all().count())
         user = auth.authenticate(remote_user=self.user2)


### PR DESCRIPTION
Override XML Test Runner to allow for test suite-wide Mock Patches
- Currently used to Patch API requests to Wharton GSR API