### PR TITLE
Refactor Get Venues

### DIFF
--- a/backend/dining/api_wrapper.py
+++ b/backend/dining/api_wrapper.py
@@ -58,8 +58,8 @@ class DiningAPIWrapper:
 
     def get_venues(self):
         venues = Venue.objects.all()
-        res = []
-        for venue in venues:
+        res = [None] * len(venues)
+        for i, venue in enumerate(venues):
             venues_obj = {"id": venue.venue_id, "name": venue.name, "image": venue.image_url}
 
             days = []
@@ -78,7 +78,7 @@ class DiningAPIWrapper:
                 ]
                 days.append(days_obj)
             venues_obj["days"] = days
-            res.append(venues_obj)
+            res[i] = venues_obj
         return res
 
     def load_menu(self, date=timezone.now().date()):

--- a/backend/dining/api_wrapper.py
+++ b/backend/dining/api_wrapper.py
@@ -57,57 +57,29 @@ class DiningAPIWrapper:
             raise APIError("Dining: Connection timeout")
 
     def get_venues(self):
-        results = []
-        venues_route = OPEN_DATA_ENDPOINTS["VENUES"]
-        response = self.request("GET", venues_route)
-        if response.status_code != 200:
-            raise APIError("Dining: Error connecting to API")
-        venues = response.json()["result_data"]["campuses"]["203"]["cafes"]
-        for key, value in venues.items():
-            # Cleaning up json response
-            venue = Venue.objects.filter(venue_id=key).first()
-            value["name"] = venue.name
-            value["image"] = venue.image_url if venue else None
+        venues = Venue.objects.all()
+        res = []
+        for venue in venues:
+            venues_obj = {"id": venue.venue_id, "name": venue.name, "image": venue.image_url}
 
-            value["id"] = int(key)
-            remove_items = [
-                "cor_icons",
-                "city",
-                "state",
-                "zip",
-                "latitude",
-                "longitude",
-                "description",
-                "message",
-                "eod",
-                "timezone",
-                "menu_type",
-                "menu_html",
-                "location_detail",
-                "weekly_schedule",
-            ]
-            [value.pop(item) for item in remove_items]
-            for day in value["days"]:
-                day.pop("message")
-                removed_dayparts = set()
-                for i in range(len(day["dayparts"])):
-                    daypart = day["dayparts"][i]
-                    [daypart.pop(item) for item in ["id", "hide"]]
-                    if not daypart["starttime"]:
-                        removed_dayparts.add(i)
-                        continue
-                    for time in ["starttime", "endtime"]:
-                        daypart[time] = datetime.datetime.strptime(
-                            day["date"] + "T" + daypart[time], "%Y-%m-%dT%H:%M"
-                        )
-                # Remove empty dayparts (unavailable meal times)
-                day["dayparts"] = [
-                    day["dayparts"][i]
-                    for i in range(len(day["dayparts"]))
-                    if i not in removed_dayparts
+            days = []
+            # get info for a week
+            for day_offset in range(7):
+                days_obj = dict()
+
+                date = datetime.datetime.today() + datetime.timedelta(days=day_offset)
+                date = date.strftime("%Y-%m-%d")
+                days_obj["date"] = date
+
+                # get starttimes and endtimes from DiningMenu objects
+                days_obj["dayparts"] = [
+                    {"starttime": menu.start_time, "endtime": menu.end_time, "label": menu.service}
+                    for menu in DiningMenu.objects.filter(venue=venue, date=date).all()
                 ]
-            results.append(value)
-        return results
+                days.append(days_obj)
+            venues_obj["days"] = days
+            res.append(venues_obj)
+        return res
 
     def load_menu(self, date=timezone.now().date()):
         """
@@ -155,17 +127,17 @@ class DiningAPIWrapper:
                 dining_menu.save()
 
     def load_stations(self, station_response):
-        # Store stations into list
-        stations = list()
-        for station_data in station_response:
+        stations = [None] * len(station_response)
+        for i, station_data in enumerate(station_response):
             # TODO: This is inefficient for venues such as Houston Market
             station = DiningStation.objects.create(name=station_data["label"])
             item_ids = [int(item) for item in station_data["items"]]
+
             # Bulk add the items into the station
             items = DiningItem.objects.filter(item_id__in=item_ids)
             station.items.add(*items)
             station.save()
-            stations.append(station)
+            stations[i] = station
         return stations
 
     def load_items(self, item_response):

--- a/backend/dining/api_wrapper.py
+++ b/backend/dining/api_wrapper.py
@@ -63,18 +63,19 @@ class DiningAPIWrapper:
 
         res = [None] * len(venues)
         for i, venue in enumerate(venues):
-            venues_obj = {"id": venue.venue_id, "name": venue.name, "image": venue.image_url}
+            venue_obj = {"id": venue.venue_id, "name": venue.name, "image": venue.image_url}
+            venue_menus = menus.filter(venue=venue)
             days = []
             for date in dates:
                 days_obj = dict()
                 days_obj["date"] = date.strftime("%Y-%m-%d")
                 days_obj["dayparts"] = [
                     {"starttime": menu.start_time, "endtime": menu.end_time, "label": menu.service}
-                    for menu in menus.filter(venue=venue, date=date).all()
+                    for menu in venue_menus.filter(date=date).all()
                 ]
                 days.append(days_obj)
-            venues_obj["days"] = days
-            res[i] = venues_obj
+            venue_obj["days"] = days
+            res[i] = venue_obj
         return res
 
     def load_menu(self, date=timezone.now().date()):

--- a/backend/dining/api_wrapper.py
+++ b/backend/dining/api_wrapper.py
@@ -58,23 +58,19 @@ class DiningAPIWrapper:
 
     def get_venues(self):
         venues = Venue.objects.all()
+        dates = [timezone.now() + datetime.timedelta(days=i) for i in range(7)]
+        menus = DiningMenu.objects.filter(date__gt=dates[0], date__lte=dates[-1])
+
         res = [None] * len(venues)
         for i, venue in enumerate(venues):
             venues_obj = {"id": venue.venue_id, "name": venue.name, "image": venue.image_url}
-
             days = []
-            # get info for a week
-            for day_offset in range(7):
+            for date in dates:
                 days_obj = dict()
-
-                date = timezone.now() + datetime.timedelta(days=day_offset)
-                date = date.strftime("%Y-%m-%d")
-                days_obj["date"] = date
-
-                # get starttimes and endtimes from DiningMenu objects
+                days_obj["date"] = date.strftime("%Y-%m-%d")
                 days_obj["dayparts"] = [
                     {"starttime": menu.start_time, "endtime": menu.end_time, "label": menu.service}
-                    for menu in DiningMenu.objects.filter(venue=venue, date=date).all()
+                    for menu in menus.filter(venue=venue, date=date).all()
                 ]
                 days.append(days_obj)
             venues_obj["days"] = days

--- a/backend/dining/api_wrapper.py
+++ b/backend/dining/api_wrapper.py
@@ -67,7 +67,7 @@ class DiningAPIWrapper:
             for day_offset in range(7):
                 days_obj = dict()
 
-                date = datetime.datetime.today() + datetime.timedelta(days=day_offset)
+                date = timezone.now() + datetime.timedelta(days=day_offset)
                 date = date.strftime("%Y-%m-%d")
                 days_obj["date"] = date
 

--- a/backend/tests/dining/test_views.py
+++ b/backend/tests/dining/test_views.py
@@ -50,37 +50,36 @@ def mock_request_post_error(*args, **kwargs):
 
 
 class TestTokenAndRequest(TestCase):
-    def test_expired_token(self):
-        wrapper = DiningAPIWrapper()
-        wrapper.expiration += datetime.timedelta(days=1)
-        prev_token = wrapper.token
-        prev_expiration = wrapper.expiration
+    def setUp(self):
+        self.wrapper = DiningAPIWrapper()
 
-        wrapper.update_token()
+    def test_expired_token(self):
+        self.wrapper.expiration += datetime.timedelta(days=1)
+        prev_token = self.wrapper.token
+        prev_expiration = self.wrapper.expiration
+
+        self.wrapper.update_token()
 
         # assert that nothing has changed
-        self.assertEqual(prev_token, wrapper.token)
-        self.assertEqual(prev_expiration, wrapper.expiration)
+        self.assertEqual(prev_token, self.wrapper.token)
+        self.assertEqual(prev_expiration, self.wrapper.expiration)
 
     @mock.patch("requests.post", mock_request_post_error)
     def test_update_token_error(self):
-        wrapper = DiningAPIWrapper()
         with self.assertRaises(APIError):
-            wrapper.update_token()
+            self.wrapper.update_token()
 
     @mock.patch("requests.post", mock_dining_requests)
     @mock.patch("requests.request", lambda **kwargs: None)
     def test_request_headers_update(self):
-        wrapper = DiningAPIWrapper()
-        res = wrapper.request(headers=dict())
+        res = self.wrapper.request(headers=dict())
         self.assertIsNone(res)
 
     @mock.patch("requests.post", mock_dining_requests)
     @mock.patch("requests.request", mock_request_raise_error)
     def test_request_api_error(self):
-        wrapper = DiningAPIWrapper()
         with self.assertRaises(APIError):
-            wrapper.request()
+            self.wrapper.request()
 
 
 @mock.patch("requests.post", mock_dining_requests)
@@ -139,7 +138,7 @@ class TestMenus(TestCase):
         self.try_structure(response.json())
 
     @mock.patch("requests.request", mock_request_raise_error)
-    def test_skip_vanue(self):
+    def test_skip_venue(self):
         Venue.objects.all().delete()
         Venue.objects.create(venue_id=747, name="Skip", image_url="URL")
         wrapper = DiningAPIWrapper()

--- a/backend/tests/dining/test_views.py
+++ b/backend/tests/dining/test_views.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from dining.api_wrapper import APIError, DiningAPIWrapper
-from dining.models import Venue, DiningMenu
+from dining.models import DiningMenu, Venue
 
 
 User = get_user_model()

--- a/backend/tests/dining/test_views.py
+++ b/backend/tests/dining/test_views.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from dining.api_wrapper import APIError, DiningAPIWrapper
-from dining.models import Venue
+from dining.models import Venue, DiningMenu
 
 
 User = get_user_model()
@@ -137,15 +137,13 @@ class TestMenus(TestCase):
         response = self.client.get("/dining/menus/2022-10-04/")
         self.try_structure(response.json())
 
-    @mock.patch("requests.request", mock_request_raise_error)
+    @mock.patch("requests.request", mock_dining_requests)
     def test_skip_venue(self):
         Venue.objects.all().delete()
         Venue.objects.create(venue_id=747, name="Skip", image_url="URL")
         wrapper = DiningAPIWrapper()
-        try:
-            wrapper.load_menu()
-        except APIError:
-            self.fail("Venue was not skipped.")
+        wrapper.load_menu()
+        self.assertEqual(DiningMenu.objects.count(), 0)
 
 
 class TestPreferences(TestCase):

--- a/backend/tests/dining/test_views.py
+++ b/backend/tests/dining/test_views.py
@@ -36,14 +36,18 @@ def mock_dining_requests(url, *args, **kwargs):
     with open(file_path) as data:
         return Mock(json.load(data), 200)
 
+
 def mock_request_raise_error(*args, **kwargs):
     raise ConnectionError
+
 
 def mock_request_post_error(*args, **kwargs):
     class Mock:
         def json(self):
             return {"error": None}
+
     return Mock()
+
 
 class TestTokenAndRequest(TestCase):
     def test_expired_token(self):

--- a/backend/tests/dining/test_views.py
+++ b/backend/tests/dining/test_views.py
@@ -45,16 +45,13 @@ class TestVenues(TestCase):
         response = self.client.get(reverse("venues"))
         for entry in response.json():
             self.assertIn("name", entry)
-            self.assertIn("address", entry)
             self.assertIn("days", entry)
             self.assertIn("image", entry)
             self.assertIn("id", entry)
             for day in entry["days"]:
                 self.assertIn("date", day)
-                self.assertIn("status", day)
                 self.assertIn("dayparts", day)
-        # Should be 16, however Lauder Retail is closed
-        self.assertEqual(15, len(response.json()))
+        self.assertEqual(16, len(response.json()))
 
 
 class TestMenus(TestCase):


### PR DESCRIPTION
Instead of requesting data from UPenn every time the `/api/dining/venues` endpoint is, we gather the data from the DiningMenu objects we already hold.