### PR TITLE
Unique Portal Visits

### DIFF
--- a/backend/penndata/urls.py
+++ b/backend/penndata/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from penndata.views import Analytics, Calendar, Events, Fitness, HomePage, HomePageOrdering, News
+from penndata.views import Analytics, Calendar, Events, Fitness, HomePage, HomePageOrdering, News, UniqueCounterView
 
 
 urlpatterns = [
@@ -11,4 +11,5 @@ urlpatterns = [
     path("order/", HomePageOrdering.as_view(), name="home-page-order"),
     path("fitness/", Fitness.as_view(), name="fitness"),
     path("analytics/", Analytics.as_view(), name="analytics"),
+    path("eventcount/", UniqueCounterView.as_view(), name="eventcounter")
 ]

--- a/backend/penndata/views.py
+++ b/backend/penndata/views.py
@@ -282,7 +282,7 @@ class UniqueCounterView(APIView):
         if "poll_id" in request.query_params:
             query["poll__id"] = request.query_params["poll_id"]
         if len(query) != 1:
-            return Response({"detail": "missing poll/post id"}, status=400)
+            return Response({"detail": "require 1 id out of post_id or poll_id"}, status=400)
         query["is_interaction"] = (
             request.query_params.get("is_interaction", "false").lower() == "true"
         )

--- a/backend/tests/penndata/test_views.py
+++ b/backend/tests/penndata/test_views.py
@@ -307,3 +307,7 @@ class TestUniqueCounterView(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 0)
+
+    def test_get_unique_counter_no_id(self):
+        response = self.client.get(reverse("eventcounter"))
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
* Adds `eventcount/` endpoint under portal app to return the number of unique interactions for either polls or posts
* Adds test cases for new endpoint