### PR TITLE
Laundry Temp Fix

### DIFF
--- a/backend/laundry/api_wrapper.py
+++ b/backend/laundry/api_wrapper.py
@@ -49,7 +49,8 @@ def parse_a_hall(hall_link):
     detailed = []
 
     try:
-        page = requests.get(hall_link, timeout=60)
+        page = requests.get(hall_link, timeout=60, headers={"Authorization": "Basic Sure-Nothing-Could-Go-Wrong-With-This-HaHa-Not"})
+        # page = requests.get(hall_link, timeout=60)
     except (ConnectTimeout, ReadTimeout):
         return {"washers": washers, "dryers": dryers, "details": detailed}
 

--- a/backend/laundry/api_wrapper.py
+++ b/backend/laundry/api_wrapper.py
@@ -49,7 +49,11 @@ def parse_a_hall(hall_link):
     detailed = []
 
     try:
-        page = requests.get(hall_link, timeout=60, headers={"Authorization": "Basic Sure-Nothing-Could-Go-Wrong-With-This-HaHa-Not"})
+        page = requests.get(
+            hall_link,
+            timeout=60,
+            headers={"Authorization": "Basic Sure-Nothing-Could-Go-Wrong-With-This-HaHa-Not"},
+        )
         # page = requests.get(hall_link, timeout=60)
     except (ConnectTimeout, ReadTimeout):
         return {"washers": washers, "dryers": dryers, "details": detailed}

--- a/backend/pennmobile/settings/base.py
+++ b/backend/pennmobile/settings/base.py
@@ -155,7 +155,8 @@ CELERY_BROKER_URL = REDIS_URL
 CELERY_TIMEZONE = TIME_ZONE
 
 # Laundry API URL
-LAUNDRY_URL = os.environ.get("LAUNDRY_URL", "http://suds.kite.upenn.edu")
+# LAUNDRY_URL = os.environ.get("LAUNDRY_URL", "http://suds.kite.upenn.edu")
+LAUNDRY_URL = "http://laundry.sketchy.dev/"
 
 # Dining API Credentials
 DINING_USERNAME = os.environ.get("DINING_USERNAME", None)

--- a/backend/tests/laundry/test_api_wrapper.py
+++ b/backend/tests/laundry/test_api_wrapper.py
@@ -2,14 +2,14 @@ import os
 from unittest import mock
 
 from django.test import TestCase
+from django.conf import settings
 
 from laundry.api_wrapper import all_status, hall_status, save_data
 from laundry.models import LaundryRoom, LaundrySnapshot
 from tests.laundry.test_commands import fakeLaundryGet
 
 
-LAUNDRY_URL = os.environ.get("LAUNDRY_URL", "http://suds.kite.upenn.edu")
-ALL_URL = f"{LAUNDRY_URL}/?location="
+ALL_URL = f"{settings.LAUNDRY_URL}/?location="
 
 
 @mock.patch("requests.get", fakeLaundryGet)

--- a/backend/tests/laundry/test_api_wrapper.py
+++ b/backend/tests/laundry/test_api_wrapper.py
@@ -1,8 +1,7 @@
-import os
 from unittest import mock
 
-from django.test import TestCase
 from django.conf import settings
+from django.test import TestCase
 
 from laundry.api_wrapper import all_status, hall_status, save_data
 from laundry.models import LaundryRoom, LaundrySnapshot

--- a/backend/tests/laundry/test_commands.py
+++ b/backend/tests/laundry/test_commands.py
@@ -1,6 +1,7 @@
 import csv
 from io import StringIO
 from unittest import mock
+
 from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase

--- a/backend/tests/laundry/test_commands.py
+++ b/backend/tests/laundry/test_commands.py
@@ -1,7 +1,7 @@
 import csv
 from io import StringIO
 from unittest import mock
-
+from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -9,7 +9,7 @@ from laundry.models import LaundryRoom, LaundrySnapshot
 
 
 def fakeLaundryGet(url, *args, **kwargs):
-    if "suds.kite.upenn.edu" in url:
+    if settings.LAUNDRY_URL in url:
         with open("tests/laundry/laundry_snapshot.html", "rb") as f:
             m = mock.MagicMock(content=f.read())
         return m


### PR DESCRIPTION
- Problem: unable to hit Penn's Laundry endpoint outside of Penn's network
- [TEMPORARY SOLUTION]: hit a different URL that acts as Laundry endpoint (info provided by Raspberry pi on Penn's network that basically makes laundry info info accessible to outside Penn's network)