### PR TITLE
Creating User Analytics Endpoints

### DIFF
--- a/backend/penndata/models.py
+++ b/backend/penndata/models.py
@@ -45,6 +45,10 @@ class FitnessSnapshot(models.Model):
     def __str__(self):
         return f"Room Name: {self.room.name} | {self.date.date()}"
 
+class AnalyticsType(models.Model):
+    name = models.CharField(max_length=255)
+    data_str_required = models.BooleanField()
+    data_num_required = models.BooleanField()
 
 class AnalyticsEvent(models.Model):
     # TODO: would it be better to just have a type field, similar to that
@@ -52,13 +56,11 @@ class AnalyticsEvent(models.Model):
     # that way, we can get rid of the post/portal fields since this should be
     # more generic?
     user = models.ForeignKey(User, on_delete=models.CASCADE)
+    type = models.ForeignKey(AnalyticsType, on_delete=models.CASCADE)
     created_at = models.DateTimeField(default=timezone.now)
-    cell_type = models.CharField(max_length=255)
-    index = models.IntegerField(default=0)
-    post = models.ForeignKey(Post, on_delete=models.CASCADE, null=True)
-    poll = models.ForeignKey(Poll, on_delete=models.CASCADE, null=True)
-    is_interaction = models.BooleanField(default=False)
-    data = models.CharField(max_length=255, null=True)
+    clicked = models.CharField(max_length=255)
+    data_str = models.CharField(max_length=512, null=True)
+    data_num = models.FloatField(null=True)
 
     def __str__(self):
-        return f"{self.cell_type}-{self.user.username}"
+        return f"{self.type.name}-{self.user.username}"

--- a/backend/penndata/models.py
+++ b/backend/penndata/models.py
@@ -47,6 +47,10 @@ class FitnessSnapshot(models.Model):
 
 
 class AnalyticsEvent(models.Model):
+    # TODO: would it be better to just have a type field, similar to that
+    # of the NotificationSettings model, where we limit type
+    # that way, we can get rid of the post/portal fields since this should be
+    # more generic?
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     created_at = models.DateTimeField(default=timezone.now)
     cell_type = models.CharField(max_length=255)

--- a/backend/penndata/views.py
+++ b/backend/penndata/views.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 import requests
 from bs4 import BeautifulSoup
@@ -287,3 +288,30 @@ class UniqueCounterView(APIView):
             request.query_params.get("is_interaction", "false").lower() == "true"
         )
         return Response({"count": AnalyticsEvent.objects.filter(**query).count()})
+
+
+class NewsAnalyticsView(APIView):
+    """
+    GET: determines number of unique visits for a given link
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        """
+        Creates AnalyticsEvent for user when they click on a news article
+        """
+        title = request.data.get("title")
+        link = request.data.get("link")
+        is_interaction = request.data.get("is_interaction", False)
+        if not link or not title:
+            return Response({"error": "Missing title or link."}, status=400)
+
+        data = json.dumps({"title": title, "link": link})
+        AnalyticsEvent.objects.create(
+            user=request.user,
+            cell_type="news",
+            is_interaction=is_interaction,
+            data=data,
+        )
+        return Response({"success": "Analytics event created"})


### PR DESCRIPTION
We are introducing User Analytics to Penn Mobile, calculating a variety of information on a per-user basis. 

**Features**
- [ ] Penn Mobile Streak
- [ ] Time spent on Penn Mobile
- [ ] DP Home Page (Number of clicks)
- [ ] Post and Polls (Number of clicks, Total Votes)
- [ ] Classes and Building Times, Commute Times
- [ ] Laundry (Number of reminders)
- [ ] Fitness (Number of times viewed, which areas they check the most)
- [ ] Dining (Which menus they've clicked, most frequented dining hall based on Mobile views)

_The views should be all async._

_This will be a large PR, but will allow Penn Mobile to collect statistics which will help future decision making, and would be interesting for users._