### PR TITLE
Ignore Canceled GSR Bookings

### DIFF
--- a/backend/gsr_booking/management/commands/labs_gsr_data.py
+++ b/backend/gsr_booking/management/commands/labs_gsr_data.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         time_used = 0
         print("| Owner:\t | Taken From:\t | Location:\t | Time Start:\t\t | Duration:")
         for res in reservations:
-            bookings = GSRBooking.objects.filter(reservation=res)
+            bookings = GSRBooking.objects.filter(reservation=res, is_cancelled=False)
             for booking in bookings:
                 duration = (booking.end - booking.start).total_seconds() / 60
                 start = localtime(booking.start).strftime("%m/%d/%Y @ %H:%M")


### PR DESCRIPTION
Modifies the `labs_gsr_data` command to not show canceled GSR bookings.