### PR TITLE
Add git blame ignore for black upgrade

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# upgrade black
+e7d0dc785ebb25677dce021cba276de5b2d95b78


### PR DESCRIPTION
Everyone needs to run to update their git config file to use the added file:`git config blame.ignoreRevsFile .git-blame-ignore-revs`

Also github should automatically pick up on it