### PR TITLE
Fix Custom Admin

### DIFF
--- a/backend/pennmobile/admin.py
+++ b/backend/pennmobile/admin.py
@@ -32,3 +32,6 @@ class CustomAdminSite(admin.AdminSite):
 
 class PennMobileAdminConfig(AdminConfig):
     default_site = "pennmobile.admin.CustomAdminSite"
+
+
+admin.AdminSite = CustomAdminSite  # anything else that overrides default admin should override ours


### PR DESCRIPTION
makes sure django-labs-account uses our custom admin (and not overrides it)