### PR TITLE
Remove Me Groups

### DIFF
--- a/backend/gsr_booking/serializers.py
+++ b/backend/gsr_booking/serializers.py
@@ -20,21 +20,13 @@ class GroupRoomBookingRequestSerializer(serializers.Serializer):
         return obj["lid"] == 1
 
 
-class MiniUserSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = User
-        fields = ["username", "first_name", "last_name"]
-
-
 class GroupMembershipSerializer(serializers.ModelSerializer):
-    user = MiniUserSerializer(read_only=True)
     group = serializers.SlugRelatedField(slug_field="name", queryset=Group.objects.all())
     color = serializers.SlugRelatedField(slug_field="color", read_only=True, source="group")
 
     class Meta:
         model = GroupMembership
         fields = [
-            "user",
             "group",
             "type",
             "pennkey_allow",
@@ -71,29 +63,6 @@ class GroupField(serializers.RelatedField):
 
     def to_internal_value(self, data):
         return None  # TODO: If you want to update based on BookingField, implement this.
-
-
-class UserSerializer(serializers.ModelSerializer):
-    booking_groups = serializers.SerializerMethodField()
-
-    def get_booking_groups(self, obj):
-        result = []
-        for membership in GroupMembership.objects.filter(accepted=True, user=obj):
-            result.append(
-                {
-                    "name": membership.group.name,
-                    "id": membership.group.id,
-                    "color": membership.group.color,
-                    "pennkey_allow": membership.pennkey_allow,
-                    "notifications": membership.notifications,
-                }
-            )
-
-        return result
-
-    class Meta:
-        model = User
-        fields = ["username", "booking_groups"]
 
 
 class GSRSerializer(serializers.ModelSerializer):

--- a/backend/gsr_booking/urls.py
+++ b/backend/gsr_booking/urls.py
@@ -10,16 +10,16 @@ from gsr_booking.views import (
     GroupMembershipViewSet,
     GroupViewSet,
     Locations,
+    MyMembershipViewSet,
     RecentGSRs,
     ReservationsView,
-    UserViewSet,
 )
 from utils.cache import Cache
 
 
 router = routers.DefaultRouter()
 
-router.register(r"users", UserViewSet)
+router.register(r"mymemberships", MyMembershipViewSet, "mymemberships")
 router.register(r"membership", GroupMembershipViewSet)
 router.register(r"groups", GroupViewSet)
 

--- a/backend/tests/user/test_notifs.py
+++ b/backend/tests/user/test_notifs.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from identity.identity import attest, container, get_platform_jwks
 from rest_framework.test import APIClient
 
-from gsr_booking.models import GSR, Group, GSRBooking, Reservation
+from gsr_booking.models import GSR, GSRBooking, Reservation
 from user.models import NotificationSetting, NotificationToken
 
 
@@ -350,7 +350,6 @@ class TestSendGSRReminders(TestCase):
             start=g.start,
             end=g.end,
             creator=self.test_user,
-            group=Group.objects.get(owner=self.test_user),
         )
 
         g.reservation = r

--- a/backend/user/models.py
+++ b/backend/user/models.py
@@ -3,7 +3,6 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from gsr_booking.models import Group
 from laundry.models import LaundryRoom
 from penndata.models import FitnessRoom
 
@@ -71,7 +70,6 @@ def create_or_update_user_profile(sender, instance, created, **kwargs):
     object exists for that User, it will create one
     """
     Profile.objects.get_or_create(user=instance)
-    Group.objects.get_or_create(owner=instance, name="Me", color="#14f7d1")
 
     # notifications
     token, _ = NotificationToken.objects.get_or_create(user=instance)


### PR DESCRIPTION
We did a GSR refactor that removed the need for "Me" groups last year
- "Me" groups existed in the first place so we could treat booking GSRs for users the same as booking GSRs for groups.
- Turns out the logic can be optimized if we separate the use cases so we did just that in the GSR refactor, using `group=None` to just book the group for the given user. 

This PR removes the the leftovers to __erase the idea of "Me" groups completely from our codebase__. 


Also did a small refactor with a group membership view. 
- __Note__: I checked iOS code and `users` (now `/mymemberships`), `membership`, and `groups` isn't used at all
  - We probably will never implement group feature. But its probably worth refactoring this code so that it makes sense, _eventually_. Since if we are going to keep it, might as well avoid confusion and make the business logic clear. Right now it is pretty messy. 