### PR TITLE
Allow Anyone Delete Token

### DIFF
--- a/backend/user/views.py
+++ b/backend/user/views.py
@@ -42,7 +42,12 @@ class UserView(generics.RetrieveUpdateAPIView):
 
 
 class NotificationTokenView(APIView, ABC):
-    permission_classes = [IsAuthenticated]
+    # permission_classes = [IsAuthenticated]
+    def get_permissions(self):
+        if self.request.method == "DELETE":
+            return []
+        return [IsAuthenticated()]
+
     queryset = None
 
     def get_defaults(self):

--- a/backend/user/views.py
+++ b/backend/user/views.py
@@ -42,7 +42,6 @@ class UserView(generics.RetrieveUpdateAPIView):
 
 
 class NotificationTokenView(APIView, ABC):
-    # permission_classes = [IsAuthenticated]
     def get_permissions(self):
         if self.request.method == "DELETE":
             return []


### PR DESCRIPTION
This feels a little bad. The assumption we are making is that people will not get ahold of someone else's device's notification token. 

But the worst that could happen is the attacker can hijack notifications sent to the device. The attacker will never get ahold of notifications actually meant for the user since users must be logged in to become associated with a particular token. 


TODO: add test in later PR