### PR TITLE
[Notifications] Add APNS and FCM Credentials

### DIFF
--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -30,7 +30,7 @@ export class MyChart extends PennLabsChart {
             name: "penn-mobile",
             subPath: "ios-key",
             mountPath: "/app/ios_key.p8",
-          }
+          },
         ],
         env: [
           { name: 'REDIS_URL', value: 'redis://penn-mobile-redis:6379' },
@@ -50,7 +50,15 @@ export class MyChart extends PennLabsChart {
             name: "penn-mobile",
             subPath: "ios-key",
             mountPath: "/app/ios_key.p8",
-          }
+          },
+          {
+            name: 'ios-credentials-prod',
+            mountPath: '/app/notifications/prod',
+          },
+          {
+            name: 'ios-credentials-dev',
+            mountPath: '/app/notifications/dev',
+          },
         ]
       },
       domains: [

--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -52,13 +52,17 @@ export class MyChart extends PennLabsChart {
             mountPath: "/app/ios_key.p8",
           },
           {
-            name: 'ios-credentials-prod',
-            mountPath: '/app/notifications/prod',
+            name: 'penn-mobile-apns-prod',
+            mountPath: '/app/secrets/notifications/ios/prod',
           },
           {
-            name: 'ios-credentials-dev',
-            mountPath: '/app/notifications/dev',
+            name: 'penn-mobile-apns-dev',
+            mountPath: '/app/secrets/notifications/ios/dev',
           },
+          {
+            name: 'penn-mobile-fcm',
+            mountPath: '/app/secrets/notifications/android',
+          }
         ]
       },
       domains: [


### PR DESCRIPTION
Path to credentials sent on slack. They are in `/app` but so is the `ios-key`, so we can just migrate them altogether eventually.