### PR TITLE
Fix CI/CD Workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -92,6 +92,14 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - uses: actions/download-artifact@v4
+          with:
+            pattern: build-backend
+        - uses: actions/download-artifact@v4
+          with:
+            pattern: build-frontend
+        - uses: actions/download-artifact@v4
+          with:
+            pattern: pennlabs~penn-mobile~*
         - uses: geekyeggo/delete-artifact@v5
           with:
             name: |-

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -56,9 +56,6 @@ jobs:
           name: build-backend
           path: /tmp/image.tar
       - uses: actions/download-artifact@v4
-        with:
-          path: tmp
-          merge-multiple: true
     needs: backend-check
 
   build-frontend:

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -93,6 +93,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
+        with:
+            path: tmp
+            merge-multiple: true
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: |-

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -93,18 +93,16 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions/download-artifact@v4
           with:
-            pattern: build-backend
-        - uses: actions/download-artifact@v4
-          with:
-            pattern: build-frontend
-        - uses: actions/download-artifact@v4
-          with:
-            pattern: pennlabs~penn-mobile~*
+            pattern: build-*
         - uses: geekyeggo/delete-artifact@v5
           with:
             name: |-
               build-backend
               build-frontend
+        - name: Load docker images
+          run: |-
+            docker load --input build-backend/image.tar
+            docker load --input build-frontend/image.tar
       needs:
         - build-backend
         - build-frontend

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -86,27 +86,6 @@ jobs:
           path: /tmp/image.tar
     needs: frontend-check
 
-  debug:
-      name: Replicate Error
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/download-artifact@v4
-          with:
-            pattern: build-*
-        - uses: geekyeggo/delete-artifact@v5
-          with:
-            name: |-
-              build-backend
-              build-frontend
-        - name: Load docker images
-          run: |-
-            docker load --input build-backend/image.tar
-            docker load --input build-frontend/image.tar
-      needs:
-        - build-backend
-        - build-frontend
-
   publish:
     name: Publish Images
     runs-on: ubuntu-latest
@@ -114,6 +93,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
+        with:
+          pattern: build-*
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: |-

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -55,7 +55,6 @@ jobs:
         with:
           name: build-backend
           path: /tmp/image.tar
-      - uses: actions/download-artifact@v4
     needs: backend-check
 
   build-frontend:
@@ -87,6 +86,21 @@ jobs:
           path: /tmp/image.tar
     needs: frontend-check
 
+  debug:
+      name: Replicate Error
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/download-artifact@v4
+        - uses: geekyeggo/delete-artifact@v5
+          with:
+            name: |-
+              build-backend
+              build-frontend
+      needs:
+        - build-backend
+        - build-frontend
+
   publish:
     name: Publish Images
     runs-on: ubuntu-latest
@@ -94,9 +108,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
-        with:
-            path: tmp
-            merge-multiple: true
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: |-

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -55,6 +55,10 @@ jobs:
         with:
           name: build-backend
           path: /tmp/image.tar
+      - uses: actions/download-artifact@v4
+        with:
+          path: tmp
+          merge-multiple: true
     needs: backend-check
 
   build-frontend:


### PR DESCRIPTION
Due to deprication of GH artifacts-related actions, some changes were needed to allow the images to be published.

**The problem:**
For some reason, the docker build step started creating artifacts related to its own builds. These were not present in previous successful workflow runs (so I'm inclined to believe that Docker recently changed this).
<img width="492" alt="image" src="https://github.com/user-attachments/assets/0a76bc9b-738d-46aa-8de4-c21b89a1fac0" />
The workflow we use only uses the `build-frontend` and `build-backend` images uploaded in the previous steps. Further, the download action fails to download these Docker-uploaded artifacts, leading to a failure for artifacts that are not even used.

**The fix:**
`actions/download-artifact@v4` has a new flag called `pattern` which allows the use of a filter. As such, we can filter for `build-frontend` and `build-backend` by passing in this parameter. This forces only downloading these two artifacts, which will succeed.
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/ab448c5e-22ac-4c48-a9c2-5a378b84789f" />

https://github.com/pennlabs/penn-mobile/actions/runs/13888718422/job/38857154032
