### PR TITLE
Bump shared actions version and "fix" validation

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -92,6 +92,14 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - uses: actions/download-artifact@v4
+          with:
+            pattern: build-backend
+        - uses: actions/download-artifact@v4
+          with:
+            pattern: build-frontend
+        - uses: actions/download-artifact@v4
+          with:
+            pattern: pennlabs~penn-mobile~*
         - uses: geekyeggo/delete-artifact@v5
           with:
             name: |-

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -56,9 +56,6 @@ jobs:
           name: build-backend
           path: /tmp/image.tar
       - uses: actions/download-artifact@v4
-        with:
-          path: tmp
-          merge-multiple: true
     needs: backend-check
 
   build-frontend:

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -118,7 +118,7 @@ jobs:
 
   deploy:
     name: "Deploy"
-    uses: pennlabs/shared-actions/.github/workflows/deployment.yaml@v0.1
+    uses: pennlabs/shared-actions/.github/workflows/deployment.yaml@v0.1.5
     with:
       githubRef: ${{ github.ref }}
       gitSha: ${{ github.sha }}

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -93,6 +93,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
+        with:
+            path: tmp
+            merge-multiple: true
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: |-

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -93,18 +93,16 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions/download-artifact@v4
           with:
-            pattern: build-backend
-        - uses: actions/download-artifact@v4
-          with:
-            pattern: build-frontend
-        - uses: actions/download-artifact@v4
-          with:
-            pattern: pennlabs~penn-mobile~*
+            pattern: build-*
         - uses: geekyeggo/delete-artifact@v5
           with:
             name: |-
               build-backend
               build-frontend
+        - name: Load docker images
+          run: |-
+            docker load --input build-backend/image.tar
+            docker load --input build-frontend/image.tar
       needs:
         - build-backend
         - build-frontend

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -86,27 +86,6 @@ jobs:
           path: /tmp/image.tar
     needs: frontend-check
 
-  debug:
-      name: Replicate Error
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/download-artifact@v4
-          with:
-            pattern: build-*
-        - uses: geekyeggo/delete-artifact@v5
-          with:
-            name: |-
-              build-backend
-              build-frontend
-        - name: Load docker images
-          run: |-
-            docker load --input build-backend/image.tar
-            docker load --input build-frontend/image.tar
-      needs:
-        - build-backend
-        - build-frontend
-
   publish:
     name: Publish Images
     runs-on: ubuntu-latest
@@ -114,6 +93,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
+        with:
+          pattern: build-*
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: |-

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -55,7 +55,6 @@ jobs:
         with:
           name: build-backend
           path: /tmp/image.tar
-      - uses: actions/download-artifact@v4
     needs: backend-check
 
   build-frontend:
@@ -87,6 +86,21 @@ jobs:
           path: /tmp/image.tar
     needs: frontend-check
 
+  debug:
+      name: Replicate Error
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/download-artifact@v4
+        - uses: geekyeggo/delete-artifact@v5
+          with:
+            name: |-
+              build-backend
+              build-frontend
+      needs:
+        - build-backend
+        - build-frontend
+
   publish:
     name: Publish Images
     runs-on: ubuntu-latest
@@ -94,9 +108,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
-        with:
-            path: tmp
-            merge-multiple: true
       - uses: geekyeggo/delete-artifact@v5
         with:
           name: |-

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -55,6 +55,10 @@ jobs:
         with:
           name: build-backend
           path: /tmp/image.tar
+      - uses: actions/download-artifact@v4
+        with:
+          path: tmp
+          merge-multiple: true
     needs: backend-check
 
   build-frontend:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,11 @@
+# Temporary until actual validation implemented.
+
+name: Validate manifests
+on: push
+jobs:
+  validate:
+    name: Validate manifests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Workflow step that always passes
+        run: echo "Success!"


### PR DESCRIPTION
Kubernetes deployment script updated to v0.1.5 and validation.yaml has been updated to always pass until validation _actually_ is taking place (see pennlabs/website and pennlabs/penn-clubs).

