### PR TITLE
Bump shared actions version

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -118,7 +118,7 @@ jobs:
 
   deploy:
     name: "Deploy"
-    uses: pennlabs/shared-actions/.github/workflows/deployment.yaml@v0.1
+    uses: pennlabs/shared-actions/.github/workflows/deployment.yaml@v0.1.5
     with:
       githubRef: ${{ github.ref }}
       gitSha: ${{ github.sha }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,9 @@
+name: Validate manifests
+on: push
+jobs:
+  validate:
+    name: Validate manifests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Workflow step that always passes
+        run: echo "Success!"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,9 +1,0 @@
-name: Validate manifests
-on: push
-jobs:
-  validate:
-    name: Validate manifests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Workflow step that always passes
-        run: echo "Success!"


### PR DESCRIPTION
The Kubernetes deployment script must be updated to v0.1.5 to properly deploy (see pennlabs/penn-clubs).