### PR TITLE
make ID serialize with page model

### DIFF
--- a/backend/wrapped/serializers.py
+++ b/backend/wrapped/serializers.py
@@ -32,7 +32,7 @@ class PageSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Page
-        fields = ["name", "template_path", "combined_stats", "duration"]
+        fields = ["id", "name", "template_path", "combined_stats", "duration"]
 
     def get_combined_stats(self, obj):
         if not (semester := self.context.get("semester", obj)):


### PR DESCRIPTION
Include the `id` field in the JSON response for wrapped pages.