### PR TITLE
Added healthcheck to mobile backend

### DIFF
--- a/backend/penndata/views.py
+++ b/backend/penndata/views.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from requests.exceptions import ConnectionError
-from rest_framework import generics
+from rest_framework import generics, status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -29,6 +29,11 @@ from penndata.serializers import (
     HomePageOrderSerializer,
 )
 from pennmobile.analytics import LabsAnalytics
+
+
+class Health(APIView):
+    def get(self, request):
+        return Response({"message": "OK"}, status=status.HTTP_200_OK)
 
 
 class News(APIView):

--- a/backend/pennmobile/urls.py
+++ b/backend/pennmobile/urls.py
@@ -5,6 +5,8 @@ from django.urls import include, path
 from django.views.generic import TemplateView
 from rest_framework.schemas import get_schema_view
 
+from penndata.views import Health
+
 
 urlpatterns = [
     path("gsr/", include("gsr_booking.urls")),
@@ -56,6 +58,7 @@ def universal_identifier_link(request):
 urlpatterns = [
     path("api/", include(urlpatterns)),
     path("", include((urlpatterns, "apex"))),
+    path("health/", Health.as_view(), name="health"),
     path(
         ".well-known/apple-app-site-association", universal_identifier_link, name="universal-links"
     ),

--- a/backend/tests/penndata/test_views.py
+++ b/backend/tests/penndata/test_views.py
@@ -7,6 +7,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
+from rest_framework import status
 from rest_framework.test import APIClient
 
 from dining.models import Venue
@@ -34,6 +35,14 @@ def fakeFitnessGet(url, *args, **kwargs):
 
 
 User = get_user_model()
+
+
+class HealthTestCase(TestCase):
+    def test_health_check(self):
+        url = reverse("health")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"message": "OK"})
 
 
 class TestNews(TestCase):


### PR DESCRIPTION
Added a healthcheck path to mobile backend to ping for the status page (status.pennlabs.org).

Penn Mobile Backend is currently pinged on https://pennmobile.org/api/documentation/.