### PR TITLE
Decrease API request timeout to 5 seconds

### DIFF
--- a/backend/gsr_booking/api_wrapper.py
+++ b/backend/gsr_booking/api_wrapper.py
@@ -242,7 +242,7 @@ class PennGroupsBookingWrapper(AbstractBookingWrapper):
             response = requests.get(
                 url,
                 auth=HTTPBasicAuth(settings.PENNGROUPS_USERNAME, settings.PENNGROUPS_PASSWORD),
-                timeout=16,
+                timeout=5,
             )
 
             # Check HTTP status first


### PR DESCRIPTION
Reduced timeout for API requests from 16 to 5 seconds.

They fixed the issue (or at least brought it back below 16 seconds per request lol). If this leads to a higher volume of sentry errors we will adjust it again.