### PR TITLE
Update AASA to prove pennmobile domain ownership

### DIFF
--- a/backend/pennmobile/urls.py
+++ b/backend/pennmobile/urls.py
@@ -43,7 +43,13 @@ def universal_identifier_link(request):
                         ],
                     }
                 ]
-            }
+            },
+            "webcredentials": {
+                "apps": [
+                    "VU59R57FGM.org.pennlabs.PennMobile",
+                    "VU59R57FGM.org.pennlabs.PennMobile.dev",
+                ]
+            },
         }
     )
 


### PR DESCRIPTION
Apple has a in-built OAuth handler that requires proof that you own the callback domain using the Apple App Site Association file.

This PR updates that file to include `pennmobile.org`

cc @khoiddinh 