### PR TITLE
calendar script only gets current semester's events

### DIFF
--- a/backend/penndata/management/commands/get_calendar.py
+++ b/backend/penndata/management/commands/get_calendar.py
@@ -70,8 +70,7 @@ class Command(BaseCommand):
                 date = datetime.datetime.strptime(
                     month + day + str(current_year) + "-04:00", "%B%d%Y%z"
                 )
-                if date and date >= timezone.localtime():
-                    CalendarEvent.objects.get_or_create(event=event, date=date_info, date_obj=date)
+                CalendarEvent.objects.get_or_create(event=event, date=date_info, date_obj=date)
             except ValueError:
                 continue
 

--- a/backend/penndata/management/commands/get_calendar.py
+++ b/backend/penndata/management/commands/get_calendar.py
@@ -44,23 +44,16 @@ class Command(BaseCommand):
             },
         )
 
-        rows = table.find_all("tr")
-        current_time = timezone.localtime()
-        current_year = current_time.year
-        row_year = 0
+        first_term = table.find("tr")
+        rows = []
+        for row in first_term.find_next_siblings("tr"):
+            if row.find("th"):
+                break
+            rows.append(row)
+
+        current_year = timezone.localtime().year
 
         for row in rows:
-            header = row.find_all("th")
-
-            # Gets data from header
-            if len(header) > 0:
-                row_year = header[0].get_text().split(" ")[0]
-                continue
-
-            # Only get data from relevant year
-            if int(row_year) != current_year:
-                continue
-
             data = row.find_all("td")
             event = data[0].get_text()
             date_info = data[1].get_text()


### PR DESCRIPTION
Now database doesn't contain spring semester stuff in the fall semester. No need for the nonactive semester's data.

Stack:
[https://github.com/pennlabs/penn-mobile/pull/426](https://github.com/pennlabs/penn-mobile/pull/426)
[https://github.com/pennlabs/penn-mobile/pull/431](https://github.com/pennlabs/penn-mobile/pull/431)