### PR TITLE
Added days_ahead parameter to calendar route

### DIFF
--- a/backend/penndata/management/commands/get_calendar.py
+++ b/backend/penndata/management/commands/get_calendar.py
@@ -70,8 +70,7 @@ class Command(BaseCommand):
                 date = datetime.datetime.strptime(
                     month + day + str(current_year) + "-04:00", "%B%d%Y%z"
                 )
-                if date and date >= timezone.localtime():
-                    CalendarEvent.objects.get_or_create(event=event, date=date_info, date_obj=date)
+                CalendarEvent.objects.get_or_create(event=event, date=date_info, date_obj=date)
             except ValueError:
                 continue
 

--- a/backend/penndata/management/commands/get_calendar.py
+++ b/backend/penndata/management/commands/get_calendar.py
@@ -44,23 +44,16 @@ class Command(BaseCommand):
             },
         )
 
-        rows = table.find_all("tr")
-        current_time = timezone.localtime()
-        current_year = current_time.year
-        row_year = 0
+        first_term = table.find("tr")
+        rows = []
+        for row in first_term.find_next_siblings("tr"):
+            if row.find("th"):
+                break
+            rows.append(row)
+
+        current_year = timezone.localtime().year
 
         for row in rows:
-            header = row.find_all("th")
-
-            # Gets data from header
-            if len(header) > 0:
-                row_year = header[0].get_text().split(" ")[0]
-                continue
-
-            # Only get data from relevant year
-            if int(row_year) != current_year:
-                continue
-
             data = row.find_all("td")
             event = data[0].get_text()
             date_info = data[1].get_text()

--- a/backend/penndata/views.py
+++ b/backend/penndata/views.py
@@ -102,17 +102,20 @@ class News(APIView):
 
 class Calendar(generics.ListAPIView):
     """
-    list: Returns upcoming university events (within 2 weeks away)
+    list: Returns upcoming university events, configurable cutoff
     """
 
     permission_classes = [AllowAny]
     serializer_class = CalendarEventSerializer
 
     def get_queryset(self):
+        days_ahead = int(
+            self.request.query_params.get("days_ahead", 365)
+        )  # db contains current semester, 1 yr guarantees everything's returned
         return CalendarEvent.objects.filter(
             date_obj__gte=timezone.localtime(),
-            date_obj__lte=timezone.localtime() + timedelta(days=30),
-        )
+            date_obj__lte=timezone.localtime() + timedelta(days=days_ahead),
+        ).order_by("date_obj")
 
 
 class Events(generics.ListAPIView):

--- a/backend/tests/penndata/test_views.py
+++ b/backend/tests/penndata/test_views.py
@@ -53,13 +53,42 @@ class TestCalender(TestCase):
         call_command("get_calendar")
 
     def test_response(self):
-        response = self.client.get(reverse("calendar"))
+        response = self.client.get(reverse("calendar"), {"days_ahead": 14})
         res_json = json.loads(response.content)
+        month_name_to_num = {
+            "January": 1,
+            "February": 2,
+            "March": 3,
+            "April": 4,
+            "May": 5,
+            "June": 6,
+            "July": 7,
+            "August": 8,
+            "September": 9,
+            "October": 10,
+            "November": 11,
+            "December": 12,
+        }
 
         for event in res_json:
             self.assertEqual(len(event), 2)
             self.assertIn("event", event)
             self.assertIn("date", event)
+            month, day = event["date"].split()
+            now = timezone.localtime()
+            event_date = datetime.datetime(
+                now.year,
+                month_name_to_num[month],
+                int(day),
+                tzinfo=now.tzinfo,
+            )
+            self.assertGreaterEqual(
+                event_date, timezone.localtime()
+            )  # Database only contains events from current year
+            self.assertLessEqual(
+                event_date,
+                timezone.localtime() + datetime.timedelta(days=14),
+            )
 
 
 class TestEvent(TestCase):


### PR DESCRIPTION
## Calendar route: days_ahead param 

The calendar route ([https://pennmobile.org/api/penndata/calendar/](https://pennmobile.org/api/penndata/calendar/)) now serves a list of events for the current semester, sorted by dates.
Use the `days_ahead` query param to adjust how far ahead you want events. No value -> no cutoff

#### Use Case:
Get the semester start and end dates for dining graph, no need to manually update dates!

<img width="1100" height="438" alt="image" src="https://github.com/user-attachments/assets/cfd7496c-98f1-46ee-8a4f-b58e56e431e7" />
<img width="1102" height="898" alt="image" src="https://github.com/user-attachments/assets/64c565d6-da1a-4967-b242-dcbca81ccdba" />


Stack:
[https://github.com/pennlabs/penn-mobile/pull/426](https://github.com/pennlabs/penn-mobile/pull/426)
[https://github.com/pennlabs/penn-mobile/pull/427](https://github.com/pennlabs/penn-mobile/pull/427)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>