### PR TITLE
new semester-start-end route

### DIFF
--- a/backend/penndata/urls.py
+++ b/backend/penndata/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from penndata.views import (
     Analytics,
     Calendar,
+    CalendarStartEnd,
     Events,
     FitnessPreferences,
     FitnessRoomView,
@@ -17,6 +18,7 @@ from penndata.views import (
 urlpatterns = [
     path("news/", News.as_view(), name="news"),
     path("calendar/", Calendar.as_view(), name="calendar"),
+    path("calendar/semester-start-end", CalendarStartEnd.as_view(), name="calendar"),
     path("homepage", HomePage.as_view(), name="homepage"),
     path("events/", Events.as_view(), name="events"),
     path("events/<str:type>/", Events.as_view(), name="events-type"),

--- a/backend/penndata/views.py
+++ b/backend/penndata/views.py
@@ -115,6 +115,26 @@ class Calendar(generics.ListAPIView):
         )
 
 
+class CalendarStartEnd(generics.ListAPIView):
+    """
+    list: Returns the start and end dates of the current semester
+    """
+
+    permission_classes = [AllowAny]
+    serializer_class = CalendarEventSerializer
+
+    def get_queryset(self):
+        start = (
+            CalendarEvent.objects.filter(event__icontains="first day of classes").first()
+            or CalendarEvent.objects.first()
+        )
+        end = (
+            CalendarEvent.objects.filter(event__icontains="term ends").first()
+            or CalendarEvent.objects.last()
+        )
+        return [start, end]
+
+
 class Events(generics.ListAPIView):
     """
     list:

--- a/backend/tests/penndata/test_views.py
+++ b/backend/tests/penndata/test_views.py
@@ -11,7 +11,7 @@ from rest_framework.test import APIClient
 
 from dining.models import Venue
 from laundry.models import LaundryRoom
-from penndata.models import AnalyticsEvent, Event, FitnessRoom, FitnessSnapshot
+from penndata.models import AnalyticsEvent, CalendarEvent, Event, FitnessRoom, FitnessSnapshot
 from portal.models import Poll, Post
 
 
@@ -60,6 +60,26 @@ class TestCalender(TestCase):
             self.assertEqual(len(event), 2)
             self.assertIn("event", event)
             self.assertIn("date", event)
+
+
+class TestCalendarStartEnd(TestCase):
+    def test_get_semester_start_end(self):
+        CalendarEvent.objects.create(event="Orientation", date="August 20, 2026")
+        CalendarEvent.objects.create(event="First Day of Classes", date="August 25, 2026")
+        CalendarEvent.objects.create(event="Fall Break", date="October 8, 2026")
+        CalendarEvent.objects.create(event="Term Ends", date="December 22, 2026")
+        CalendarEvent.objects.create(event="Winter Break", date="December 23, 2026")
+
+        response = self.client.get("/penndata/calendar/semester-start-end")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            [
+                {"event": "First Day of Classes", "date": "August 25, 2026"},
+                {"event": "Term Ends", "date": "December 22, 2026"},
+            ],
+        )
 
 
 class TestEvent(TestCase):


### PR DESCRIPTION
### New route for semester start/end date. Original route is unchanged
<img width="1181" height="418" alt="image" src="https://github.com/user-attachments/assets/bb912154-e1d9-4aa0-b68a-b756187d628f" />


Stack:
[https://github.com/pennlabs/penn-mobile/pull/426](https://github.com/pennlabs/penn-mobile/pull/426)
[https://github.com/pennlabs/penn-mobile/pull/431](https://github.com/pennlabs/penn-mobile/pull/431)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>